### PR TITLE
Add /* @noflip */ switch to skip flipping some rules

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -17,6 +17,17 @@
         "test",
         "infra"
       ]
+    },
+    {
+      "login": "ahmedelgabri",
+      "name": "Ahmed El Gabri",
+      "avatar_url": "https://avatars.githubusercontent.com/u/63876?v=3",
+      "profile": "https://gabri.me",
+      "contributions": [
+        "code",
+        "doc",
+        "test"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ console.log(styles) // logs {paddingLeft: 23}
 </script>
 ```
 
+You can also control which rules you don't want to flip by adding a `/* @noflip */` CSS comment to your rule
+
+```javascript
+const rtlCSSJS = require('rtl-css-js')
+const styles = rtlCSSJS({paddingLeft: '20px /* @noflip */'})
+console.log(styles) // logs {paddingLeft: '20px /* @noflip */' }
+```
+
 ## Caveats
 
 ### `background`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ RTL conversion for CSS in JS objects
 [![downloads][downloads-badge]][npm-stat]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
 [![Code of Conduct][coc-badge]][coc]
@@ -94,8 +94,8 @@ I'm not aware of any, if you are please [make a pull request](http://makeapullre
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/rtl-css-js/commits?author=kentcdodds) [⚠️](https://github.com/kentcdodds/rtl-css-js/commits?author=kentcdodds) 🚇 |
-| :---: |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/rtl-css-js/commits?author=kentcdodds) [⚠️](https://github.com/kentcdodds/rtl-css-js/commits?author=kentcdodds) 🚇 | [<img src="https://avatars.githubusercontent.com/u/63876?v=3" width="100px;"/><br /><sub>Ahmed El Gabri</sub>](https://gabri.me)<br />[💻](https://github.com/kentcdodds/rtl-css-js/commits?author=ahmedelgabri) [📖](https://github.com/kentcdodds/rtl-css-js/commits?author=ahmedelgabri) [⚠️](https://github.com/kentcdodds/rtl-css-js/commits?author=ahmedelgabri) |
+| :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification. Contributions of any kind welcome!

--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ function convert(object) {
       // you're welcome to later code 😺
       originalValue = originalValue.trim()
     }
-    const {key, value} = convertProperty(originalKey, object[originalKey])
+    const {key, value} = convertProperty(originalKey, originalValue)
     newObj[key] = value
     return newObj
   }, {})

--- a/src/index.js
+++ b/src/index.js
@@ -135,8 +135,9 @@ function convert(object) {
  * @return {Object} the new {key, value} pair
  */
 function convertProperty(originalKey, originalValue) {
-  const key = getPropertyDoppelganger(originalKey)
-  const value = getValueDoppelganger(key, originalValue)
+  const isNoFlip = /\/\*\s?@noflip\s?\*\//.test(originalValue)
+  const key = isNoFlip ? originalKey : getPropertyDoppelganger(originalKey)
+  const value = isNoFlip ? originalValue : getValueDoppelganger(key, originalValue)
   return {key, value}
 }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -163,6 +163,10 @@ const unchanged = [
   [{rightxx: 10}],
   [{backgroundImage: 'mozLinearGradient(#326cc1, #234e8c)'}],
   [{backgroundImage: 'webkitGradient(linear, 100% 0%, 0% 0%, from(#666666), to(#ffffff))'}],
+  [{background: '#000 url(/foo/bar.png) no-repeat 77% 40% /* @noflip */'}],
+  [{padding: '1px 2px 3px 4px !important /* @noflip */'}],
+  [{float: 'left /* @noflip */'}],
+  [{borderColor: 'red #f00 hsl(0, 100%, 50%) hsla(0, 100%, 50%, 0.5) /* @noflip */'}],
 ]
 
 shortTests.forEach(shortTest => {
@@ -196,7 +200,7 @@ Object.keys(tests)
     } else {
       test(title, testFn)
     }
-    
+
     function testFn() {
       expect(convert(...input)).toEqual(output)
     }


### PR DESCRIPTION
It's a very common use case with RTL websites that sometimes you might not need to flip some rules. So this PR adds the ability to skip the flipping by appending a CSS comment `/* @noflip */` to your CSS rule.

I assumed that a CSS comment won't break any CSS in JS solutions because it's valid CSS.

So all these syntax variations should be ok:

- `property: value /* @noflip */`
- `property: value !important /* @noflip */`
- `property: value /* @noflip */ !important`
- `property: /* @noflip */ value !important`
- `property: /* @noflip */ value`

Also these variations of `/* @noflip */`

- `/* @noflip */`
- `/*@noflip */`
- `/* @noflip*/`
- `/*@noflip*/`

Tests are passing but my solution feels ugly & bit confusing so maybe you have a better idea & I'll also think about it later.

And in the process I did a minor fix on [`LINE125`](https://github.com/kentcdodds/rtl-css-js/blob/master/src/index.js#L125) here aee1d9ab243d9953ad7bdb75765b854c022d10e9

Hope that's ok 😊