### PR TITLE
fix(conditional/undefined): add conditional for undefined css property value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -158,6 +158,9 @@ function getPropertyDoppelganger(property) {
  */
 function getValueDoppelganger(key, originalValue) {
   /* eslint complexity:[2, 7] */ // let's try to keep the complexity down... If we have to do this much more, let's break this up
+  if (originalValue === undefined) {
+    return undefined
+  }
   if (isObject(originalValue)) {
     return convert(originalValue) // recurssion 🌀
   }


### PR DESCRIPTION
**What**
![screen shot 2017-02-09 at 12 46 11 pm](https://cloud.githubusercontent.com/assets/14946478/22802492/d97b4cbc-eec5-11e6-8d47-47276e8604f2.png)

**Why** --- **See `TODO`**
When using aphrodite's StyleSheet.create function in conjunction with rtl-css-js in our React app, we get a blocking error during the conversion. The values of some css properties are passed as props, and are not always going to be passed into the component, which makes them undefined.

![screen shot 2017-02-09 at 12 52 17 pm](https://cloud.githubusercontent.com/assets/14946478/22802682/a267a3f0-eec6-11e6-8ecd-89ae2af752e4.png)

**Fixes**
Since the problem is that rtl-css-js runs a replace on what it thinks is a string, but is actually an undefined value. Therefore, as seen in the picture above, the user can set a default empty string for the given css property.


