### PR TITLE
Handle quartet values for margins

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,6 +101,7 @@ const propertyValueConverters = {
     return propertyValueConverters.backgroundPosition(value)
   },
 }
+propertyValueConverters.margin = propertyValueConverters.padding
 propertyValueConverters.borderWidth = propertyValueConverters.padding
 propertyValueConverters.boxShadow = propertyValueConverters.textShadow
 propertyValueConverters.webkitBoxShadow = propertyValueConverters.textShadow

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -54,6 +54,7 @@ const shortTests = [
   [[{padding: '1px 2px 3px 4px'}], {padding: '1px 4px 3px 2px'}],
   [[{padding: '1px 2px 3px 4px !important', color: 'red'}], {padding: '1px 4px 3px 2px !important', color: 'red'}],
   [[{padding: 10, direction: 'rtl'}], {padding: 10, direction: 'ltr'}],
+  [[{margin: '1px 2px 3px 4px'}], {margin: '1px 4px 3px 2px'}],
   [[{float: 'left'}], {float: 'right'}],
   [[{float: 'left !important'}], {float: 'right !important'}],
   [[{clear: 'left'}], {clear: 'right'}],


### PR DESCRIPTION
Fixes #10 to make sure that margins defined like this margin: '1px 2px 3px 4px' are properly converted.