### PR TITLE
Address all falsey prop values

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -28,6 +28,13 @@
         "doc",
         "test"
       ]
+    },
+    {
+      "login": "majapw",
+      "name": "Maja Wichrowska",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/1383861?v=4",
+      "profile": "https://github.com/majapw",
+      "contributions": []
     }
   ]
 }

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -34,7 +34,10 @@
       "name": "Maja Wichrowska",
       "avatar_url": "https://avatars1.githubusercontent.com/u/1383861?v=4",
       "profile": "https://github.com/majapw",
-      "contributions": []
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ RTL conversion for CSS in JS objects
 [![downloads][downloads-badge]][npm-stat]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
 [![Code of Conduct][coc-badge]][coc]
@@ -94,8 +94,8 @@ I'm not aware of any, if you are please [make a pull request](http://makeapullre
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/rtl-css-js/commits?author=kentcdodds) [⚠️](https://github.com/kentcdodds/rtl-css-js/commits?author=kentcdodds) 🚇 | [<img src="https://avatars.githubusercontent.com/u/63876?v=3" width="100px;"/><br /><sub>Ahmed El Gabri</sub>](https://gabri.me)<br />[💻](https://github.com/kentcdodds/rtl-css-js/commits?author=ahmedelgabri) [📖](https://github.com/kentcdodds/rtl-css-js/commits?author=ahmedelgabri) [⚠️](https://github.com/kentcdodds/rtl-css-js/commits?author=ahmedelgabri) |
-| :---: | :---: |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/rtl-css-js/commits?author=kentcdodds) [⚠️](https://github.com/kentcdodds/rtl-css-js/commits?author=kentcdodds) 🚇 | [<img src="https://avatars.githubusercontent.com/u/63876?v=3" width="100px;"/><br /><sub>Ahmed El Gabri</sub>](https://gabri.me)<br />[💻](https://github.com/kentcdodds/rtl-css-js/commits?author=ahmedelgabri) [📖](https://github.com/kentcdodds/rtl-css-js/commits?author=ahmedelgabri) [⚠️](https://github.com/kentcdodds/rtl-css-js/commits?author=ahmedelgabri) | [<img src="https://avatars1.githubusercontent.com/u/1383861?v=4" width="100px;"/><br /><sub>Maja Wichrowska</sub>](https://github.com/majapw)<br /> |
+| :---: | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification. Contributions of any kind welcome!

--- a/src/index.js
+++ b/src/index.js
@@ -158,8 +158,10 @@ function getPropertyDoppelganger(property) {
  * @return {String|Number|Object} the converted value
  */
 function getValueDoppelganger(key, originalValue) {
-  /* eslint complexity:[2, 7] */ // let's try to keep the complexity down... If we have to do this much more, let's break this up
-  if (originalValue === null || typeof originalValue === 'undefined') return originalValue;
+  /* eslint complexity:[2, 8] */ // let's try to keep the complexity down... If we have to do this much more, let's break this up
+  if (originalValue === null || typeof originalValue === 'undefined') {
+    return originalValue
+  }
 
   if (isObject(originalValue)) {
     return convert(originalValue) // recurssion 🌀

--- a/src/index.js
+++ b/src/index.js
@@ -159,6 +159,8 @@ function getPropertyDoppelganger(property) {
  */
 function getValueDoppelganger(key, originalValue) {
   /* eslint complexity:[2, 7] */ // let's try to keep the complexity down... If we have to do this much more, let's break this up
+  if (originalValue === null || typeof originalValue === 'undefined') return originalValue;
+
   if (isObject(originalValue)) {
     return convert(originalValue) // recurssion 🌀
   }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -120,8 +120,8 @@ const shortTests = [
   [[{background: 'url(/foo/bar.png) 77% 40% !important'}], {background: 'url(/foo/bar.png) 23% 40% !important'}],
   [[{marginLeft: null}], {marginRight: null}],
   [[{paddingLeft: undefined}], {paddingRight: undefined}],
-  [[{':active': { marginLeft: null }}], {':active': { marginRight: null }}],
-  [[{':active': { paddingLeft: undefined }}], {':active': { paddingRight: undefined }}],
+  [[{':active': {marginLeft: null}}], {':active': {marginRight: null}}],
+  [[{':active': {paddingLeft: undefined}}], {':active': {paddingRight: undefined}}],
 ]
 
 // put short tests that should be skipped here
@@ -173,9 +173,9 @@ const unchanged = [
   [{float: 'left /* @noflip */'}],
   [{borderColor: 'red #f00 hsl(0, 100%, 50%) hsla(0, 100%, 50%, 0.5) /* @noflip */'}],
   [{margin: null}],
-  [{padding: undefined, lineHeight: 0.2 }],
-  [{':active': { border: null, color: 'blue' }}],
-  [{':active': { border: undefined, color: 'blue' }}],
+  [{padding: undefined, lineHeight: 0.2}],
+  [{':active': {border: null, color: 'blue'}}],
+  [{':active': {border: undefined, color: 'blue'}}],
 ]
 
 shortTests.forEach(shortTest => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -118,6 +118,10 @@ const shortTests = [
   [[{background: 'url(/foo/bar.png) no-repeat 77% 40%'}], {background: 'url(/foo/bar.png) no-repeat 23% 40%'}],
   [[{background: '#000 url(/foo/bar.png) no-repeat 77% 40%'}], {background: '#000 url(/foo/bar.png) no-repeat 23% 40%'}],
   [[{background: 'url(/foo/bar.png) 77% 40% !important'}], {background: 'url(/foo/bar.png) 23% 40% !important'}],
+  [[{marginLeft: null}], {marginRight: null}],
+  [[{paddingLeft: undefined}], {paddingRight: undefined}],
+  [[{':active': { marginLeft: null }}], {':active': { marginRight: null }}],
+  [[{':active': { paddingLeft: undefined }}], {':active': { paddingRight: undefined }}],
 ]
 
 // put short tests that should be skipped here
@@ -168,6 +172,10 @@ const unchanged = [
   [{padding: '1px 2px 3px 4px !important /* @noflip */'}],
   [{float: 'left /* @noflip */'}],
   [{borderColor: 'red #f00 hsl(0, 100%, 50%) hsla(0, 100%, 50%, 0.5) /* @noflip */'}],
+  [{margin: null}],
+  [{padding: undefined, lineHeight: 0.2 }],
+  [{':active': { border: null, color: 'blue' }}],
+  [{':active': { border: undefined, color: 'blue' }}],
 ]
 
 shortTests.forEach(shortTest => {


### PR DESCRIPTION
Hi @kentcdodds! I'm back... and with more of the same issue. 

So checking for falsiness in the `isObject` method was not quite enough (it addressed one scenario, but not all). With the structure of the `getValueDoppelganger` method, it made sense to just add an explicit check for `null` or `undefined` (to prevent the recursing and also the call to `.replace` and such in those scenarios).

That being said, there's already a comment about complexity and this adds another branch to the method. What do you think?