### PR TITLE
feat(border): add `borderLeftWidth` to properties to convert

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ const propertiesToConvert = arrayToObject([
   ['borderLeft', 'borderRight'],
   ['borderLeftColor', 'borderRightColor'],
   ['borderLeftStyle', 'borderRightStyle'],
+  ['borderLeftWidth', 'borderRightWidth'],
   ['borderTopLeftRadius', 'borderTopRightRadius'],
   ['borderBottomLeftRadius', 'borderBottomRightRadius'],
 ])

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -80,6 +80,7 @@ const shortTests = [
   [[{borderLeft: '1px solid red'}], {borderRight: '1px solid red'}],
   [[{borderLeftColor: 'red'}], {borderRightColor: 'red'}],
   [[{borderLeftStyle: 'red'}], {borderRightStyle: 'red'}],
+  [[{borderLeftWidth: '2px'}], {borderRightWidth: '2px'}],
   [[{borderColor: 'red green blue white'}], {borderColor: 'red white blue green'}],
   [[{borderColor: 'red #f00 rgb(255, 0, 0) rgba(255, 0, 0, 0.5)'}], {borderColor: 'red rgba(255, 0, 0, 0.5) rgb(255, 0, 0) #f00'}],
   [[{borderColor: 'red #f00 hsl(0, 100%, 50%) hsla(0, 100%, 50%, 0.5)'}], {borderColor: 'red hsla(0, 100%, 50%, 0.5) hsl(0, 100%, 50%) #f00'}],


### PR DESCRIPTION
Hi! This PR adds support for converting the `border-left-width` CSS property
(https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-width), since sometimes this is
defined explicitly rather than the `borderLeft` shorthand.

cc: @majapw