### PR TITLE
feat(gradient): add linear-gradient to properties to convert

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -38,6 +38,16 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "yzimet",
+      "name": "Yaniv",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/6600720?v=4",
+      "profile": "https://github.com/yzimet",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ console.log(styles) // logs {paddingLeft: '20px /* @noflip */' }
 ### `background`
 
 Right now `background` and `backgroundImage` just replace all instances of `ltr` with `rtl` and `right` with `left`.
-This is so you can have a different image for your LTR and RTL. Note that this is case sensitive! Must be lower case.
-Note also that it *will not* change `bright` to `bleft`. It's a _little_ smarter than that. But this is definitely
-something to consider with your URLs.
+This is so you can have a different image for your LTR and RTL, and in order to flip linear gradients. Note that
+this is case sensitive! Must be lower case. Note also that it *will not* change `bright` to `bleft`.
+It's a _little_ smarter than that. But this is definitely something to consider with your URLs.
 
 ## Inspiration
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ RTL conversion for CSS in JS objects
 [![downloads][downloads-badge]][npm-stat]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
 [![Code of Conduct][coc-badge]][coc]
@@ -96,8 +96,8 @@ I'm not aware of any, if you are please [make a pull request](http://makeapullre
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/rtl-css-js/commits?author=kentcdodds) [⚠️](https://github.com/kentcdodds/rtl-css-js/commits?author=kentcdodds) 🚇 | [<img src="https://avatars.githubusercontent.com/u/63876?v=3" width="100px;"/><br /><sub>Ahmed El Gabri</sub>](https://gabri.me)<br />[💻](https://github.com/kentcdodds/rtl-css-js/commits?author=ahmedelgabri) [📖](https://github.com/kentcdodds/rtl-css-js/commits?author=ahmedelgabri) [⚠️](https://github.com/kentcdodds/rtl-css-js/commits?author=ahmedelgabri) | [<img src="https://avatars1.githubusercontent.com/u/1383861?v=4" width="100px;"/><br /><sub>Maja Wichrowska</sub>](https://github.com/majapw)<br /> |
-| :---: | :---: | :---: |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/rtl-css-js/commits?author=kentcdodds "Code") [⚠️](https://github.com/kentcdodds/rtl-css-js/commits?author=kentcdodds "Tests") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") | [<img src="https://avatars.githubusercontent.com/u/63876?v=3" width="100px;"/><br /><sub>Ahmed El Gabri</sub>](https://gabri.me)<br />[💻](https://github.com/kentcdodds/rtl-css-js/commits?author=ahmedelgabri "Code") [📖](https://github.com/kentcdodds/rtl-css-js/commits?author=ahmedelgabri "Documentation") [⚠️](https://github.com/kentcdodds/rtl-css-js/commits?author=ahmedelgabri "Tests") | [<img src="https://avatars1.githubusercontent.com/u/1383861?v=4" width="100px;"/><br /><sub>Maja Wichrowska</sub>](https://github.com/majapw)<br />[💻](https://github.com/kentcdodds/rtl-css-js/commits?author=majapw "Code") [⚠️](https://github.com/kentcdodds/rtl-css-js/commits?author=majapw "Tests") | [<img src="https://avatars2.githubusercontent.com/u/6600720?v=4" width="100px;"/><br /><sub>Yaniv</sub>](https://github.com/yzimet)<br />[💻](https://github.com/kentcdodds/rtl-css-js/commits?author=yzimet "Code") [⚠️](https://github.com/kentcdodds/rtl-css-js/commits?author=yzimet "Tests") |
+| :---: | :---: | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification. Contributions of any kind welcome!

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -168,6 +168,34 @@ const shortTests = [
     [{backgroundImage: 'url(/foo/bar-rtl.png)'}],
     {backgroundImage: 'url(/foo/bar-ltr.png)'},
   ],
+  [
+    [{backgroundImage: 'linear-gradient(to left top, blue, red)'}],
+    {backgroundImage: 'linear-gradient(to right top, blue, red)'},
+  ],
+  [
+    [{backgroundImage: 'linear-gradient(to right top, blue, red)'}],
+    {backgroundImage: 'linear-gradient(to left top, blue, red)'},
+  ],
+  [
+    [{backgroundImage: 'linear-gradient(to left, #00ff00 0%, #ff0000 100%)'}],
+    {backgroundImage: 'linear-gradient(to right, #00ff00 0%, #ff0000 100%)'},
+  ],
+  [
+    [{backgroundImage: 'repeating-linear-gradient(to left top, blue, red)'}],
+    {backgroundImage: 'repeating-linear-gradient(to right top, blue, red)'},
+  ],
+  [
+    [{backgroundImage: 'repeating-linear-gradient(to right top, blue, red)'}],
+    {backgroundImage: 'repeating-linear-gradient(to left top, blue, red)'},
+  ],
+  [
+    [{backgroundImage: 'repeating-linear-gradient(to left, #00ff00 0%, #ff0000 100%)'}],
+    {backgroundImage: 'repeating-linear-gradient(to right, #00ff00 0%, #ff0000 100%)'},
+  ],
+  [
+    [{background: '#000 linear-gradient(to left top, blue, red)'}],
+    {background: '#000 linear-gradient(to right top, blue, red)'},
+  ],
   [[{backgroundPosition: 'left top'}], {backgroundPosition: 'right top'}],
   [[{backgroundPosition: 'left -5px'}], {backgroundPosition: 'right -5px'}],
   [[{backgroundPosition: '77% 40%'}], {backgroundPosition: '23% 40%'}],
@@ -275,6 +303,9 @@ const unchanged = [
   [{backgroundPositionX: 10}],
   [{backgroundPositionY: '40%'}],
   [{backgroundImage: 'linear-gradient(#eb01a5, #d13531)'}],
+  [{backgroundImage: 'linear-gradient(45deg, blue, red)'}],
+  [{backgroundImage: 'repeating-linear-gradient(#eb01a5, #d13531)'}],
+  [{backgroundImage: 'repeating-linear-gradient(45deg, blue, red)'}],
   [{background: 'url(/foo/bright.png)'}],
   [{background: 'url(/foo/leftovers.png)'}],
   [{background: 'url("http'}],

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ const propertyValueConverters = {
     return propertyValueConverters.backgroundImage(value)
   },
   backgroundImage(value) {
-    if (!includes(value, 'url(')) {
+    if (!includes(value, 'url(') && !includes(value, 'linear-gradient(')) {
       return value
     }
     // sorry for the regex 😞, but basically this replaces _every_ instance of `ltr`, `rtl`, `right`, and `left` with


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Add support for flipping the following gradient values in the `background` and `backgroundImage` properties:
- [`linear-gradient`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient)
- [`repeating-linear-gradient`](https://developer.mozilla.org/en-US/docs/Web/CSS/repeating-linear-gradient)

<!-- Why are these changes necessary? -->
**Why**:
To support RTL gradients

<!-- How were these changes implemented? -->
**How**:
Added conditional to the `backgroundImage` propertyValueConverter that checks for "linear-gradient" in the value.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
