### PR TITLE
fix(content): Don't convert value of "content"

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -346,6 +346,8 @@ const unchanged = [
   [{transform: 'translateX(0px)'}],
   [{transform: 'translateY(30px)'}],
   [{transform: 'translateZ(30px)'}],
+  [{content: 'left'}],
+  [{content: 'right'}],
 ]
 
 shortTests.forEach(shortTest => {

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,8 @@ const propertiesToConvert = arrayToObject([
   ['borderBottomLeftRadius', 'borderBottomRightRadius'],
 ])
 
+const propsToIgnore = ['content']
+
 // this is the same as the propertiesToConvert except for values
 const valuesToConvert = arrayToObject([
   ['ltr', 'rtl'],
@@ -52,6 +54,13 @@ function convert(object) {
       // you're welcome to later code 😺
       originalValue = originalValue.trim()
     }
+
+    // Some properties should never be transformed
+    if (propsToIgnore.includes(originalKey)) {
+      newObj[originalKey] = originalValue
+      return newObj
+    }
+
     const {key, value} = convertProperty(originalKey, originalValue)
     newObj[key] = value
     return newObj


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Prevent the value of `content` from being converted

<!-- Why are these changes necessary? -->
**Why**:
The value of content should not be converted based on the flow direction
of the document, as it will usually not be the intended result since
`right` is not the RLT equvalent of `left` in the context of `content`.

The equvalent of `left` would be `اليسار` or `يسار` in Arabic and
`שמאל` or `שמאלה` in Hebrew.

<!-- How were these changes implemented? -->
**How**:
Add a `propsToIgnore` array, with css properties that should not be converted (whitelist), and add `content` to it.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
