### PR TITLE
fix(convert function): "Array.prototype.includes" throwing in IE

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import {
+  includes,
   arrayToObject,
   isNumber,
   isObject,
@@ -56,7 +57,7 @@ function convert(object) {
     }
 
     // Some properties should never be transformed
-    if (propsToIgnore.includes(originalKey)) {
+    if (includes(propsToIgnore, originalKey)) {
       newObj[originalKey] = originalValue
       return newObj
     }


### PR DESCRIPTION
`Array.prototype.includes` doesn't exist in IE, causing a TypeError to be thrown.
This PR fixes it by replacing it with the `include()` util.

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions --> N/A

closes #27
