### PR TITLE
Allow for boolean values for styles

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -348,6 +348,8 @@ const unchanged = [
   [{transform: 'translateZ(30px)'}],
   [{content: 'left'}],
   [{content: 'right'}],
+  [{foo: true}],
+  [{foo: false}],
 ]
 
 shortTests.forEach(shortTest => {

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -11,6 +11,10 @@ function arrayToObject(array) {
   }, {})
 }
 
+function isBoolean(val) {
+  return typeof val === 'boolean'
+}
+
 function isNumber(val) {
   return typeof val === 'number'
 }
@@ -130,6 +134,7 @@ export {
   flipSign,
   handleQuartetValues,
   includes,
+  isBoolean,
   isNullOrUndefined,
   isNumber,
   isObject,

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import {
   includes,
   arrayToObject,
+  isBoolean,
   isNumber,
   isObject,
   isString,
@@ -108,8 +109,8 @@ function getPropertyDoppelganger(property) {
  * @return {String|Number|Object} the converted value
  */
 function getValueDoppelganger(key, originalValue) {
-  /* eslint complexity:[2, 7] */ // let's try to keep the complexity down... If we have to do this much more, let's break this up
-  if (isNullOrUndefined(originalValue)) {
+  /* eslint complexity:[2, 8] */ // let's try to keep the complexity down... If we have to do this much more, let's break this up
+  if (isNullOrUndefined(originalValue) || isBoolean(originalValue)) {
     return originalValue
   }
 


### PR DESCRIPTION
**What**:
Allows for `styleKey: true` and `styleKey: false` styles to pass through unchanged and without breaking.

**Why**:
When defining our styles in JS, we end up doing a lot of conditional values, things like `background: hasBackground && 'white'`. As a result, often our values end up as booleans that simply get tossed by whatever style processer we are using. Recently we have moved to evaluating all styles with `rtl-css-js` and booleans always end up erroring and crashing the app. This change addresses that issue.

**How**:
Wrote a test, added an extra helper method a la `isNullOrUndefined`

**Checklist**:
- [ ] Documentation N/A
- [X] Tests
- [X] Ready to be merged 
- [X] Added myself to contributors table

@yzimet @kentcdodds 
