### PR TITLE
feat(browser-prefixes) add support for PascalCase prefixes

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -103,6 +103,14 @@ const shortTests = [
     [{mozBoxShadow: '-1px 2px 3px 3px red'}],
     {mozBoxShadow: '1px 2px 3px 3px red'},
   ],
+  [
+    [{WebkitBoxShadow: '-1px 2px 3px 3px red'}],
+    {WebkitBoxShadow: '1px 2px 3px 3px red'},
+  ],
+  [
+    [{MozBoxShadow: '-1px 2px 3px 3px red'}],
+    {MozBoxShadow: '1px 2px 3px 3px red'},
+  ],
   [[{borderLeft: 0}], {borderRight: 0}],
   [[{borderLeft: '1px solid red'}], {borderRight: '1px solid red'}],
   [[{borderLeftColor: 'red'}], {borderRightColor: 'red'}],
@@ -280,7 +288,16 @@ const shortTests = [
     {webkitTransform: 'translateX(-30px)'},
   ],
   [[{mozTransform: 'translateX(30px)'}], {mozTransform: 'translateX(-30px)'}],
+  [
+    [{WebkitTransform: 'translateX(30px)'}],
+    {WebkitTransform: 'translateX(-30px)'},
+  ],
+  [[{MozTransform: 'translateX(30px)'}], {MozTransform: 'translateX(-30px)'}],
   [[{transformOrigin: '10% 50%'}], {transformOrigin: '90% 50%'}],
+  [[{webkitTransformOrigin: '10% 50%'}], {webkitTransformOrigin: '90% 50%'}],
+  [[{WebkitTransformOrigin: '10% 50%'}], {WebkitTransformOrigin: '90% 50%'}],
+  [[{mozTransformOrigin: '10% 50%'}], {mozTransformOrigin: '90% 50%'}],
+  [[{MozTransformOrigin: '10% 50%'}], {MozTransformOrigin: '90% 50%'}],
 ]
 
 // put short tests that should be skipped here
@@ -328,10 +345,17 @@ const unchanged = [
   [{leftxx: 10}],
   [{rightxx: 10}],
   [{backgroundImage: 'mozLinearGradient(#326cc1, #234e8c)'}],
+  [{backgroundImage: 'MozLinearGradient(#326cc1, #234e8c)'}],
   [
     {
       backgroundImage:
         'webkitGradient(linear, 100% 0%, 0% 0%, from(#666666), to(#ffffff))',
+    },
+  ],
+  [
+    {
+      backgroundImage:
+        'WebkitGradient(linear, 100% 0%, 0% 0%, from(#666666), to(#ffffff))',
     },
   ],
   [{background: '#000 url(/foo/bar.png) no-repeat 77% 40% /* @noflip */'}],

--- a/src/core/property-value-converters.js
+++ b/src/core/property-value-converters.js
@@ -158,16 +158,24 @@ const propertyValueConverters = {
 propertyValueConverters.margin = propertyValueConverters.padding
 propertyValueConverters.borderWidth = propertyValueConverters.padding
 propertyValueConverters.boxShadow = propertyValueConverters.textShadow
-propertyValueConverters.webkitBoxShadow = propertyValueConverters.textShadow
-propertyValueConverters.mozBoxShadow = propertyValueConverters.textShadow
+propertyValueConverters.webkitBoxShadow = propertyValueConverters.boxShadow
+propertyValueConverters.mozBoxShadow = propertyValueConverters.boxShadow
+propertyValueConverters.WebkitBoxShadow = propertyValueConverters.boxShadow
+propertyValueConverters.MozBoxShadow = propertyValueConverters.boxShadow
 propertyValueConverters.borderStyle = propertyValueConverters.borderColor
 propertyValueConverters.webkitTransform = propertyValueConverters.transform
 propertyValueConverters.mozTransform = propertyValueConverters.transform
+propertyValueConverters.WebkitTransform = propertyValueConverters.transform
+propertyValueConverters.MozTransform = propertyValueConverters.transform
 propertyValueConverters.transformOrigin =
   propertyValueConverters.backgroundPosition
 propertyValueConverters.webkitTransformOrigin =
   propertyValueConverters.transformOrigin
 propertyValueConverters.mozTransformOrigin =
+  propertyValueConverters.transformOrigin
+propertyValueConverters.WebkitTransformOrigin =
+  propertyValueConverters.transformOrigin
+propertyValueConverters.MozTransformOrigin =
   propertyValueConverters.transformOrigin
 
 // kebab-case versions

--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,7 @@ function getPropertyDoppelganger(property) {
  * @return {String|Number|Object} the converted value
  */
 function getValueDoppelganger(key, originalValue) {
-  /* eslint complexity:[2, 8] */ // let's try to keep the complexity down... If we have to do this much more, let's break this up
+  /* eslint complexity:[2, 9] */ // let's try to keep the complexity down... If we have to do this much more, let's break this up
   if (isNullOrUndefined(originalValue) || isBoolean(originalValue)) {
     return originalValue
   }


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Add support for WebkitBoxShadow, MozBoxShadow, WebkitTransform, MozTransform, WebkitTransformOrigin and MozTransformOrigin

<!-- Why are these changes necessary? -->
**Why**: Browser CSS prefixes can be either PacalCased or camelCased. Current Chrome supports
both `Webkit*` and `webkit*`. Firefox only supports `Moz*`, and the React `style` attribute expects browser prefixes to begin with a capital letter:
> Vendor prefixes other than ms should begin with a capital letter. This is why WebkitTransition has an uppercase "W".
([See here](https://github.com/reactjs/reactjs.org/blob/master/content/docs/reference-dom-elements.md#style))

<!-- How were these changes implemented? -->
**How**: The PascalCased props reference the original in `src/core/property-value-converters.js`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation - N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
