### PR TITLE
fix(convert): keep array values as arrays

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -298,6 +298,10 @@ const shortTests = [
   [[{WebkitTransformOrigin: '10% 50%'}], {WebkitTransformOrigin: '90% 50%'}],
   [[{mozTransformOrigin: '10% 50%'}], {mozTransformOrigin: '90% 50%'}],
   [[{MozTransformOrigin: '10% 50%'}], {MozTransformOrigin: '90% 50%'}],
+  [
+    [{animationName: [{from: {transform: 'rotate(100deg)'}, to: {transform: 'rotate(-100deg)'}}]}],
+    {animationName: [{from: {transform: 'rotate(-100deg)'}, to: {transform: 'rotate(100deg)'}}]}
+  ],
 ]
 
 // put short tests that should be skipped here
@@ -313,6 +317,8 @@ const unchanged = [
   [{xUnknown: 'a b c d'}],
   [{xUnknown: '1px 2px 3px 4px'}],
   [{xUnknown: '1px 2px 3px 4px 5px'}],
+  [{xUnknown: {}}],
+  [{xUnknown: []}],
   [{padding: 1}],
   [{padding: '1px 2px'}],
   [{padding: '1px 2px 3px'}],
@@ -381,6 +387,7 @@ const unchanged = [
   [{content: 'right'}],
   [{foo: true}],
   [{foo: false}],
+  [{animationName: [{from: {opacity: 0}, to: {opacity: 1}}]}],
 ]
 
 shortTests.forEach(shortTest => {

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ function convert(object) {
     const {key, value} = convertProperty(originalKey, originalValue)
     newObj[key] = value
     return newObj
-  }, {})
+  }, Array.isArray(object) ? [] : {})
 }
 
 /**


### PR DESCRIPTION
Hi.

We're using _rtl-css-js_ with [aphrodite](https://github.com/Khan/aphrodite) and have a problem:

```javascript
const fadeIn = { from: { opacity: 0 }, to: { opacity: 1 } };

// legit style object in aphrodite (animationName and fontFamily accepts arrays)
const rtlStyles = rtlCSSJS({ animationName: [fadeIn] });

// array is reduced to plain object like { animationName: { '0': fadeIn } }
console.log(rtlStyles); 
```

From one side, I expect that "not common" fields should not be affected by conversion and that's not _rtl-css-js_ purpose to fit every css-in-js library syntax.

From the other side, recursive conversion fits a lot of use cases (pseudo-classes/elements, nested media queries, etc.) and it's very easy to support arrays.

**What**:

So, we can fix recursive conversion to keep arrays.

**How**:

With passing an empty array to `.reduce` initial value.

**Bad things**:
1. This fix does not cover custom iterable values other than arrays;
2. I skipped pre-commit formatting as it forces code style not similar to the existing file formatting.

**Checklist**:
- [ ] <del>Documentation</del> (N/A)
- [x] Tests
- [x] Ready to be merged
- [ ] <del>Added myself to contributors table</del> (N/A)