### PR TITLE
Add `transition` support

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -299,8 +299,42 @@ const shortTests = [
   [[{mozTransformOrigin: '10% 50%'}], {mozTransformOrigin: '90% 50%'}],
   [[{MozTransformOrigin: '10% 50%'}], {MozTransformOrigin: '90% 50%'}],
   [
-    [{animationName: [{from: {transform: 'rotate(100deg)'}, to: {transform: 'rotate(-100deg)'}}]}],
-    {animationName: [{from: {transform: 'rotate(-100deg)'}, to: {transform: 'rotate(100deg)'}}]}
+    [
+      {
+        animationName: [
+          {
+            from: {transform: 'rotate(100deg)'},
+            to: {transform: 'rotate(-100deg)'},
+          },
+        ],
+      },
+    ],
+    {
+      animationName: [
+        {
+          from: {transform: 'rotate(-100deg)'},
+          to: {transform: 'rotate(100deg)'},
+        },
+      ],
+    },
+  ],
+  [[{transition: 'margin-right 4s'}], {transition: 'margin-left 4s'}],
+  [
+    [{transition: 'padding-left 4s ease-in-out'}],
+    {transition: 'padding-right 4s ease-in-out'},
+  ],
+  [[{transition: 'all 0.5s ease-out'}], {transition: 'all 0.5s ease-out'}],
+  [[{transition: 'inherit'}], {transition: 'inherit'}],
+  [[{transition: 'initial'}], {transition: 'initial'}],
+  [[{transition: 'unset'}], {transition: 'unset'}],
+  [
+    [{transition: 'transform: 300ms, left 300ms'}],
+    {transition: 'transform: 300ms, right 300ms'},
+  ],
+  [[{transitionProperty: 'margin-right'}], {transitionProperty: 'margin-left'}],
+  [
+    [{transitionProperty: 'padding-right, right'}],
+    {transitionProperty: 'padding-left, left'},
   ],
 ]
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -324,15 +324,11 @@ const shortTests = [
     {transition: 'padding-right 4s ease-in-out'},
   ],
   [[{transition: 'all 0.5s ease-out'}], {transition: 'all 0.5s ease-out'}],
-  [[{transition: 'inherit'}], {transition: 'inherit'}],
-  [[{transition: 'initial'}], {transition: 'initial'}],
-  [[{transition: 'unset'}], {transition: 'unset'}],
   [
     [{transition: 'transform: 300ms, left 300ms'}],
     {transition: 'transform: 300ms, right 300ms'},
   ],
   [[{transitionProperty: 'margin-right'}], {transitionProperty: 'margin-left'}],
-  [[{transitionProperty: 'display'}], {transitionProperty: 'display'}],
   [
     [{transitionProperty: 'padding-right, right'}],
     {transitionProperty: 'padding-left, left'},
@@ -423,6 +419,10 @@ const unchanged = [
   [{foo: true}],
   [{foo: false}],
   [{animationName: [{from: {opacity: 0}, to: {opacity: 1}}]}],
+  [{transition: 'inherit'}],
+  [{transition: 'initial'}],
+  [{transition: 'unset'}],
+  [{transitionProperty: 'display'}],
 ]
 
 shortTests.forEach(shortTest => {

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -332,6 +332,7 @@ const shortTests = [
     {transition: 'transform: 300ms, right 300ms'},
   ],
   [[{transitionProperty: 'margin-right'}], {transitionProperty: 'margin-left'}],
+  [[{transitionProperty: 'display'}], {transitionProperty: 'display'}],
   [
     [{transitionProperty: 'padding-right, right'}],
     {transitionProperty: 'padding-left, left'},

--- a/src/__tests__/kebab.js
+++ b/src/__tests__/kebab.js
@@ -4,7 +4,7 @@
 
 import convert from '../'
 
-// These are the same as the short tests only with kebab-casing 
+// These are the same as the short tests only with kebab-casing
 const kebabTests = [
   [[{'padding-left': 23}], {'padding-right': 23}],
   [[{'padding-right': 23}], {'padding-left': 23}],
@@ -24,13 +24,22 @@ const kebabTests = [
     [{'box-shadow': 'inset -6px 3px 8px 5px rgba(0, 0, 0, 0.25)'}],
     {'box-shadow': 'inset 6px 3px 8px 5px rgba(0, 0, 0, 0.25)'},
   ],
-  [[{'box-shadow': 'inset .5em 0 0 white'}], {'box-shadow': 'inset -.5em 0 0 white'}],
+  [
+    [{'box-shadow': 'inset .5em 0 0 white'}],
+    {'box-shadow': 'inset -.5em 0 0 white'},
+  ],
   [
     [{'box-shadow': 'inset 0.5em 0 0 white'}],
     {'box-shadow': 'inset -0.5em 0 0 white'},
   ],
-  [[{'box-shadow': '-1px 2px 3px 3px red'}], {'box-shadow': '1px 2px 3px 3px red'}],
-  [[{'box-shadow': '-1px 2px 3px 3px red'}], {'box-shadow': '1px 2px 3px 3px red'}],
+  [
+    [{'box-shadow': '-1px 2px 3px 3px red'}],
+    {'box-shadow': '1px 2px 3px 3px red'},
+  ],
+  [
+    [{'box-shadow': '-1px 2px 3px 3px red'}],
+    {'box-shadow': '1px 2px 3px 3px red'},
+  ],
   [
     [{'-webkit-box-shadow': '-1px 2px 3px 3px red'}],
     {'-webkit-box-shadow': '1px 2px 3px 3px red'},
@@ -64,8 +73,14 @@ const kebabTests = [
   [[{'border-top-left-radius': 0}], {'border-top-right-radius': 0}],
   [[{'border-bottom-left-radius': 0}], {'border-bottom-right-radius': 0}],
   [[{'border-radius': '1px 2px'}], {'border-radius': '2px 1px'}],
-  [[{'border-radius': '1px 2px 3px 4px'}], {'border-radius': '2px 1px 4px 3px'}],
-  [[{'border-radius': '1px 2px 3px 4px'}], {'border-radius': '2px 1px 4px 3px'}],
+  [
+    [{'border-radius': '1px 2px 3px 4px'}],
+    {'border-radius': '2px 1px 4px 3px'},
+  ],
+  [
+    [{'border-radius': '1px 2px 3px 4px'}],
+    {'border-radius': '2px 1px 4px 3px'},
+  ],
   [[{'border-radius': '15px / 0 20px'}], {'border-radius': '15px / 20px 0'}],
   [
     [{'border-radius': '1px 2px 3px 4px / 5px 6px 7px 8px'}],
@@ -75,7 +90,10 @@ const kebabTests = [
     [{'border-radius': '1px 2px 3px 4px !important'}],
     {'border-radius': '2px 1px 4px 3px !important'},
   ],
-  [[{'border-radius': '1px 2px 3px 4px'}], {'border-radius': '2px 1px 4px 3px'}],
+  [
+    [{'border-radius': '1px 2px 3px 4px'}],
+    {'border-radius': '2px 1px 4px 3px'},
+  ],
   [
     [{'border-radius': '1px 2px 3px calc(calc(2*2) * 3px)'}],
     {'border-radius': '2px 1px calc(calc(2*2) * 3px) 3px'},
@@ -93,7 +111,12 @@ const kebabTests = [
     {'background-image': 'linear-gradient(to left top, blue, red)'},
   ],
   [
-    [{'background-image': 'linear-gradient(to left, #00ff00 0%, #ff0000 100%)'}],
+    [
+      {
+        'background-image':
+          'linear-gradient(to left, #00ff00 0%, #ff0000 100%)',
+      },
+    ],
     {'background-image': 'linear-gradient(to right, #00ff00 0%, #ff0000 100%)'},
   ],
   [
@@ -101,7 +124,12 @@ const kebabTests = [
     {'background-image': 'repeating-linear-gradient(to right top, blue, red)'},
   ],
   [
-    [{'background-image': 'repeating-linear-gradient(to right top, blue, red)'}],
+    [
+      {
+        'background-image':
+          'repeating-linear-gradient(to right top, blue, red)',
+      },
+    ],
     {'background-image': 'repeating-linear-gradient(to left top, blue, red)'},
   ],
   [
@@ -117,10 +145,16 @@ const kebabTests = [
     },
   ],
   [[{'background-position': 'left top'}], {'background-position': 'right top'}],
-  [[{'background-position': 'left -5px'}], {'background-position': 'right -5px'}],
+  [
+    [{'background-position': 'left -5px'}],
+    {'background-position': 'right -5px'},
+  ],
   [[{'background-position': '77% 40%'}], {'background-position': '23% 40%'}],
   [[{'background-position': '2.3% 40%'}], {'background-position': '97.7% 40%'}],
-  [[{'background-position': '2.3210% 40%'}], {'background-position': '97.6790% 40%'}],
+  [
+    [{'background-position': '2.3210% 40%'}],
+    {'background-position': '97.6790% 40%'},
+  ],
   [[{'background-position': '0% 100%'}], {'background-position': '100% 100%'}],
   [[{'background-position': '77% -5px'}], {'background-position': '23% -5px'}],
   [
@@ -145,7 +179,19 @@ const kebabTests = [
     [{'-webkit-transform': 'translateX(30px)'}],
     {'-webkit-transform': 'translateX(-30px)'},
   ],
-  [[{'-moz-transform': 'translateX(30px)'}], {'-moz-transform': 'translateX(-30px)'}],
+  [
+    [{'-moz-transform': 'translateX(30px)'}],
+    {'-moz-transform': 'translateX(-30px)'},
+  ],
+  [
+    [{'transition-property': 'margin-right'}],
+    {'transition-property': 'margin-left'},
+  ],
+  [[{'transition-property': 'display'}], {'transition-property': 'display'}],
+  [
+    [{'transition-property': 'padding-right, right'}],
+    {'transition-property': 'padding-left, left'},
+  ],
 ]
 
 // Same as unchanged, except for kebab-casing
@@ -186,7 +232,7 @@ const unchangedKebab = [
         'red #f00 hsl(0, 100%, 50%) hsla(0, 100%, 50%, 0.5) /* @noflip */',
     },
   ],
-  [{'padding': undefined, 'line-height': 0.2}],
+  [{padding: undefined, 'line-height': 0.2}],
 ]
 
 const tests = {}

--- a/src/__tests__/kebab.js
+++ b/src/__tests__/kebab.js
@@ -187,7 +187,6 @@ const kebabTests = [
     [{'transition-property': 'margin-right'}],
     {'transition-property': 'margin-left'},
   ],
-  [[{'transition-property': 'display'}], {'transition-property': 'display'}],
   [
     [{'transition-property': 'padding-right, right'}],
     {'transition-property': 'padding-left, left'},
@@ -233,6 +232,7 @@ const unchangedKebab = [
     },
   ],
   [{padding: undefined, 'line-height': 0.2}],
+  [{'transition-property': 'display'}],
 ]
 
 const tests = {}

--- a/src/index.js
+++ b/src/index.js
@@ -59,23 +59,26 @@ const bgPosDirectionRegex = new RegExp('(left)|(right)')
  * @return {Object} the RTL converted object
  */
 function convert(object) {
-  return Object.keys(object).reduce((newObj, originalKey) => {
-    let originalValue = object[originalKey]
-    if (isString(originalValue)) {
-      // you're welcome to later code 😺
-      originalValue = originalValue.trim()
-    }
+  return Object.keys(object).reduce(
+    (newObj, originalKey) => {
+      let originalValue = object[originalKey]
+      if (isString(originalValue)) {
+        // you're welcome to later code 😺
+        originalValue = originalValue.trim()
+      }
 
-    // Some properties should never be transformed
-    if (includes(propsToIgnore, originalKey)) {
-      newObj[originalKey] = originalValue
+      // Some properties should never be transformed
+      if (includes(propsToIgnore, originalKey)) {
+        newObj[originalKey] = originalValue
+        return newObj
+      }
+
+      const {key, value} = convertProperty(originalKey, originalValue)
+      newObj[key] = value
       return newObj
-    }
-
-    const {key, value} = convertProperty(originalKey, originalValue)
-    newObj[key] = value
-    return newObj
-  }, Array.isArray(object) ? [] : {})
+    },
+    Array.isArray(object) ? [] : {},
+  )
 }
 
 /**
@@ -129,6 +132,7 @@ function getValueDoppelganger(key, originalValue) {
     newValue = valueConverter({
       value: importantlessValue,
       valuesToConvert,
+      propertiesToConvert,
       isRtl: true,
       bgImgDirectionRegex,
       bgPosDirectionRegex,

--- a/src/internal/property-value-converters.js
+++ b/src/internal/property-value-converters.js
@@ -237,6 +237,8 @@ propertyValueConverters['-moz-transform-origin'] =
 propertyValueConverters['-webkit-transition'] =
   propertyValueConverters.transition
 propertyValueConverters['-moz-transition'] = propertyValueConverters.transition
+propertyValueConverters['transition-property'] =
+  propertyValueConverters.transitionProperty
 propertyValueConverters['-webkit-transition-property'] =
   propertyValueConverters.transitionProperty
 propertyValueConverters['-moz-transition-property'] =

--- a/src/internal/property-value-converters.js
+++ b/src/internal/property-value-converters.js
@@ -118,6 +118,25 @@ const propertyValueConverters = {
       bgPosDirectionRegex,
     })
   },
+  transition({value, propertiesToConvert}) {
+    return value
+      .split(/,\s*/g)
+      .map(transition => {
+        const values = transition.split(' ')
+
+        // Property is always defined first
+        values[0] = propertiesToConvert[values[0]] || values[0]
+
+        return values.join(' ')
+      })
+      .join(', ')
+  },
+  transitionProperty({value, propertiesToConvert}) {
+    return value
+      .split(/,\s*/g)
+      .map(prop => propertiesToConvert[prop] || prop)
+      .join(', ')
+  },
   transform({value}) {
     // This was copied and modified from CSSJanus:
     // https://github.com/cssjanus/cssjanus/blob/4a40f001b1ba35567112d8b8e1d9d95eda4234c3/src/cssjanus.js#L152-L153
@@ -177,6 +196,18 @@ propertyValueConverters.WebkitTransformOrigin =
   propertyValueConverters.transformOrigin
 propertyValueConverters.MozTransformOrigin =
   propertyValueConverters.transformOrigin
+propertyValueConverters.webkitTransition = propertyValueConverters.transition
+propertyValueConverters.mozTransition = propertyValueConverters.transition
+propertyValueConverters.WebkitTransition = propertyValueConverters.transition
+propertyValueConverters.MozTransition = propertyValueConverters.transition
+propertyValueConverters.webkitTransitionProperty =
+  propertyValueConverters.transitionProperty
+propertyValueConverters.mozTransitionProperty =
+  propertyValueConverters.transitionProperty
+propertyValueConverters.WebkitTransitionProperty =
+  propertyValueConverters.transitionProperty
+propertyValueConverters.MozTransitionProperty =
+  propertyValueConverters.transitionProperty
 
 // kebab-case versions
 
@@ -203,5 +234,12 @@ propertyValueConverters['-webkit-transform-origin'] =
   propertyValueConverters.transformOrigin
 propertyValueConverters['-moz-transform-origin'] =
   propertyValueConverters.transformOrigin
+propertyValueConverters['-webkit-transition'] =
+  propertyValueConverters.transition
+propertyValueConverters['-moz-transition'] = propertyValueConverters.transition
+propertyValueConverters['-webkit-transition-property'] =
+  propertyValueConverters.transitionProperty
+propertyValueConverters['-moz-transition-property'] =
+  propertyValueConverters.transitionProperty
 
 export default propertyValueConverters


### PR DESCRIPTION
@kentcdodds 

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Adds support for `transition` and `transition-property` properties.

<!-- Why are these changes necessary? -->
**Why**: They currently don't convert. Closes https://github.com/kentcdodds/rtl-css-js/issues/39

<!-- How were these changes implemented? -->
**How**: Using the value converters pattern.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
