### PR TITLE
fix: /core should be tree shakable

### DIFF
--- a/core.js
+++ b/core.js
@@ -1,3 +1,0 @@
-/* eslint import/no-unresolved:0 */
-// this file just makes it easier to require dist/core
-module.exports = require('./dist/cjs/core.js')

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "dist",
     "core",
     "types.d.ts",
-    "core.js",
     "core.d.ts",
     "core.esm.js",
     "core.esm.d.ts"


### PR DESCRIPTION
**What**:

This PR fixes tree shaking for `/core` (`import {} from "rtl-css-js/core"`).

**Why**:

Currently import of `rtl-css-js/core` throws a warning as `rtl-css-js/dist/cjs/core.js` will be resolved. And this file contains CJS export:

```js
/* eslint import/no-unresolved:0 */
// this file just makes it easier to require dist/core
module.exports = require('./dist/cjs/core.js')
```

```
./node_modules/rtl-css-js/core.js 138 bytes [built] [code generated]
  Statement (ExpressionStatement) with side effects in source code at 3:0-46
  ModuleConcatenation bailout: Module is not an ECMAScript module
```
(webpack 5.19.0)

```
[4] ./src/main.js + 25 modules 47.2 KiB {0} [built]
    ModuleConcatenation bailout: Cannot concat with ./node_modules/rtl-css-js/core.js (<- Module is not an ECMAScript module)
```

(webpack 4.46.0)

```
src/main.js → dist/rollup.js...
[!] Error: 'convertProperty' is not exported by node_modules\rtl-css-js\core.js, imported by src\main.js
https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module
src\main.js (1:9)
1: import { convertProperty } from "rtl-css-js/core";
```
(Rollup 2.18.2 without @rollup/plugin-commonjs)

This prevents tree shaking for Webpack 4 and makes result suboptimal for Webpack 5.

**How**:

`/core.js` file was removed. There are no breaking changes as resolutions will go to `/core/package.json` first.

```
asset webpack.js 6.56 KiB [emitted] [minimized] (name: webpack)
orphan modules 20.1 KiB [orphan] 2 modules
./src/main.js + 2 modules 20.2 KiB [built] [code generated]
client (webpack 5.28.0) compiled successfully in 387 ms
```

The same is true for Node.

```js
// a.js
const { convertProperty } = require('rtl-css-js/core')
console.log(convertProperty('left', '5px'))
```

```bash
$ node -v
v12.14.1
$ node a.js
{ key: 'right', value: '5px' }
```

**Checklist**:

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
- [ ] Added myself to contributors table