### PR TITLE
feat(getValueDoppelganger): Ignore css property values with `var()`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -127,6 +127,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "ling1726",
+      "name": "Lingfan Gao",
+      "avatar_url": "https://avatars.githubusercontent.com/u/20744592?v=4",
+      "profile": "https://github.com/ling1726",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "repoType": "github",

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ is a work in progress).
   - [core](#core)
 - [Caveats](#caveats)
   - [`background`](#background)
+  - [CSS variables - `var()`](#css-variables---var)
 - [Inspiration](#inspiration)
 - [Ecosystem](#ecosystem)
 - [Other Solutions](#other-solutions)
@@ -120,6 +121,12 @@ for your LTR and RTL, and in order to flip linear gradients. Note that this is
 case sensitive! Must be lower case. Note also that it _will not_ change `bright`
 to `bleft`. It's a _little_ smarter than that. But this is definitely something
 to consider with your URLs.
+
+### CSS variables - `var()`
+
+Since it's impossible to know what the contents of a css variable are until the
+styles are actually calculated by the browser, any property value that includes
+css variables with `var()` will not be converted.
 
 ## Inspiration
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -431,6 +431,11 @@ const unchanged = [
   [{opacity: () => {}}],
   [{objectPosition: 'center bottom'}],
   [{objectPosition: '5px 10px'}], // There's no RTL-flipped equivalent for the 5px. :-(
+  [{boxShadow: 'var(--box-shadow)'}],
+  [{margin: 'var(--margin)'}],
+  [{transform: 'translate(var(--distance))'}],
+  [{transform: 'var(--transform)'}],
+  [{transform: 'translateX(var(--distance))'}],
 ]
 
 shortTests.forEach(shortTest => {

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -431,11 +431,12 @@ const unchanged = [
   [{opacity: () => {}}],
   [{objectPosition: 'center bottom'}],
   [{objectPosition: '5px 10px'}], // There's no RTL-flipped equivalent for the 5px. :-(
-  [{boxShadow: 'var(--box-shadow)'}],
+  [{boxShadow: 'var(--shadow16)'}],
   [{margin: 'var(--margin)'}],
   [{transform: 'translate(var(--distance))'}],
   [{transform: 'var(--transform)'}],
   [{transform: 'translateX(var(--distance))'}],
+  [{padding: '2px var(--foo)'}],
 ]
 
 shortTests.forEach(shortTest => {

--- a/src/internal/convert.js
+++ b/src/internal/convert.js
@@ -1,12 +1,11 @@
 import {
   includes,
   arrayToObject,
-  isBoolean,
   isFunction,
   isNumber,
   isObject,
   isString,
-  isNullOrUndefined,
+  canConvertValue,
 } from './utils'
 import propertyValueConverters from './property-value-converters'
 
@@ -113,8 +112,7 @@ export function getPropertyDoppelganger(property) {
  * @return {String|Number|Object} the converted value
  */
 export function getValueDoppelganger(key, originalValue) {
-  /* eslint complexity:[2, 10] */ // let's try to keep the complexity down... If we have to do this much more, let's break this up
-  if (isNullOrUndefined(originalValue) || isBoolean(originalValue)) {
+  if (!canConvertValue(originalValue)) {
     return originalValue
   }
 

--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -11,6 +11,10 @@ function arrayToObject(array) {
   }, {})
 }
 
+function containsCssVar(val) {
+  return typeof val === 'string' && val.match(/var\(.*\)/g)
+}
+
 function isBoolean(val) {
   return typeof val === 'boolean'
 }
@@ -131,18 +135,31 @@ function handleQuartetValues(value) {
   return [top, left, bottom, right].join(' ')
 }
 
+/**
+ *
+ * @param {String|Number|Object} value css property value to test
+ * @returns If the css property value can(should?) have an RTL equivalent
+ */
+function canConvertValue(value) {
+  return (
+    !isBoolean(value) && !isNullOrUndefined(value) && !containsCssVar(value)
+  )
+}
+
 export {
   arrayToObject,
   calculateNewBackgroundPosition,
+  canConvertValue,
   flipTransformSign as calculateNewTranslate,
   flipTransformSign,
   flipSign,
   handleQuartetValues,
   includes,
   isBoolean,
+  containsCssVar,
   isFunction,
-  isNullOrUndefined,
   isNumber,
+  isNullOrUndefined,
   isObject,
   isString,
   getValuesAsList,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

Fixes #61 which illustrates a concrete example of the problem

Since the original issue is only with `boxShadow` or `textShadow` I'm
open to any suggestions that move the `containsCssVar` check only for
that property value converter.

<!-- How were these changes implemented? -->

**How**:

Created an extra `containsCssVar` regex match and used it with the existing checks
for boolean and undefined property values. Extracted the check to a separate utility
to avoid too much complexity in the function.

I was initially worried about some edge cases:

*  `translateX(var())`
* `padding: '2px var(--foo)';`

but after testing, it seems that the results are the same before and after the changes in this PR.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
