### PR TITLE
feat: Support multiple shadows in a single shadow style

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -96,6 +96,38 @@ const shortTests = [
   [[{boxShadow: '-1px 2px 3px 3px red'}], {boxShadow: '1px 2px 3px 3px red'}],
   [[{boxShadow: '-1px 2px 3px 3px red'}], {boxShadow: '1px 2px 3px 3px red'}],
   [
+    [{boxShadow: '-1px 2px 3px 3px red, -1px 2px 3px 3px red'}],
+    {boxShadow: '1px 2px 3px 3px red, 1px 2px 3px 3px red'},
+  ],
+  [
+    [
+      {
+        boxShadow:
+          '-1px 2px 3px 3px rgba(0, 0, 0, 0.5), -1px 2px 3px 3px rgba(0, 0, 0, 0.5)',
+      },
+    ],
+    {
+      boxShadow:
+        '1px 2px 3px 3px rgba(0, 0, 0, 0.5), 1px 2px 3px 3px rgba(0, 0, 0, 0.5)',
+    },
+  ],
+  [
+    [{boxShadow: '-1px 2px rgba(0, 0, 0, 0.5), -1px 2px rgba(0, 0, 0, 0.5)'}],
+    {boxShadow: '1px 2px rgba(0, 0, 0, 0.5), 1px 2px rgba(0, 0, 0, 0.5)'},
+  ],
+  [
+    [{boxShadow: '-1px 2px red, -1px 2px red'}],
+    {boxShadow: '1px 2px red, 1px 2px red'},
+  ],
+  [
+    [{boxShadow: 'inset -1px 2px red, -1px 2px red'}],
+    {boxShadow: 'inset 1px 2px red, 1px 2px red'},
+  ],
+  [
+    [{boxShadow: 'inset -1px 2px 3px 3px red, -1px 2px 3px 3px red'}],
+    {boxShadow: 'inset 1px 2px 3px 3px red, 1px 2px 3px 3px red'},
+  ],
+  [
     [{webkitBoxShadow: '-1px 2px 3px 3px red'}],
     {webkitBoxShadow: '1px 2px 3px 3px red'},
   ],

--- a/src/internal/property-value-converters.js
+++ b/src/internal/property-value-converters.js
@@ -5,6 +5,7 @@ import {
   flipTransformSign,
   handleQuartetValues,
   getValuesAsList,
+  splitShadow,
 } from './utils'
 
 // some values require a little fudging, that fudging goes here.
@@ -16,14 +17,18 @@ const propertyValueConverters = {
     return handleQuartetValues(value)
   },
   textShadow({value}) {
-    // intentionally leaving off the `g` flag here because we only want to change the first number (which is the offset-x)
-    return value.replace(/(-*)([.|\d]+)/, (match, negative, number) => {
-      if (number === '0') {
-        return match
-      }
-      const doubleNegative = negative === '' ? '-' : ''
-      return `${doubleNegative}${number}`
+    const flippedShadows = splitShadow(value).map(shadow => {
+      // intentionally leaving off the `g` flag here because we only want to change the first number (which is the offset-x)
+      return shadow.replace(/(-*)([.|\d]+)/, (match, negative, number) => {
+        if (number === '0') {
+          return match
+        }
+        const doubleNegative = negative === '' ? '-' : ''
+        return `${doubleNegative}${number}`
+      })
     })
+
+    return flippedShadows.join(',')
   },
   borderColor({value}) {
     return handleQuartetValues(value)

--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -162,10 +162,10 @@ function splitShadow(value) {
       shadows.push(value.substring(start, end).trim())
       end++
       start = end
-    } else if (value[end] == `(`) {
+    } else if (value[end] === `(`) {
       rgba = true
       end++
-    } else if (value[end] == ')') {
+    } else if (value[end] === ')') {
       rgba = false
       end++
     } else {

--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -146,6 +146,41 @@ function canConvertValue(value) {
   )
 }
 
+/**
+ * Splits a shadow style into its separate shadows using the comma delimiter, but creating an exception
+ * for comma separated values in parentheses often used for rgba colours.
+ * @param {String} value
+ * @returns {Array} array of all box shadow values in the string
+ */
+function splitShadow(value) {
+  const shadows = []
+  let start = 0
+  let end = 0
+  let rgba = false
+  while (end < value.length) {
+    if (!rgba && value[end] === ',') {
+      shadows.push(value.substring(start, end).trim())
+      end++
+      start = end
+    } else if (value[end] == `(`) {
+      rgba = true
+      end++
+    } else if (value[end] == ')') {
+      rgba = false
+      end++
+    } else {
+      end++
+    }
+  }
+
+  // push the last shadow value if there is one
+  if (start != end) {
+    shadows.push(value.substring(start, end + 1))
+  }
+
+  return shadows
+}
+
 export {
   arrayToObject,
   calculateNewBackgroundPosition,
@@ -163,4 +198,5 @@ export {
   isObject,
   isString,
   getValuesAsList,
+  splitShadow,
 }

--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -174,6 +174,7 @@ function splitShadow(value) {
   }
 
   // push the last shadow value if there is one
+  // instanbul ignore next
   if (start != end) {
     shadows.push(value.substring(start, end + 1))
   }

--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -174,7 +174,7 @@ function splitShadow(value) {
   }
 
   // push the last shadow value if there is one
-  // instanbul ignore next
+  // istanbul ignore next
   if (start != end) {
     shadows.push(value.substring(start, end + 1))
   }


### PR DESCRIPTION
**What**:

This PR attempts to add a split function for shadows. I had to custom
write it since it needs to handle the case where `rgb(,,,)` values are
in the shadow.

After the split, the original logic to flip the offsetX value for the shadow is applied,
but to all shadows that are in the style.

**Why**:

box-shadow and text-shadow can take multiple shadows. Currently
rtl-css-js only supports flipping one single shadow value.

`1px 1px 1px 1px red, 2px 2px 2px 2px blue` will become `-1px 1px 1px 1px red, **2px** 2px 2px 2px blue`

**How**:

Read `what` section

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
