### PR TITLE
feat: Flip values even if they contain `var()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ to consider with your URLs.
 ### CSS variables - `var()`
 
 Since it's impossible to know what the contents of a css variable are until the
-styles are actually calculated by the browser, any property value that includes
-css variables with `var()` will not be converted.
+styles are actually calculated by the browser, any CSS variable contents will
+not be converted.
 
 ## Inspiration
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -41,6 +41,7 @@ const shortTests = [
   [[{left: '10px !important'}], {right: '10px !important'}],
   [[{right: '-1.5em'}], {left: '-1.5em'}],
   [[{left: '-.75em'}], {right: '-.75em'}],
+  [[{left: 'var(--css-variable)'}], {right: 'var(--css-variable)'}],
   [[{padding: '1px 2px 3px -4px'}], {padding: '1px -4px 3px 2px'}],
   [[{padding: '.25em 0ex 0pt 15px'}], {padding: '.25em 15px 0pt 0ex'}],
   [[{padding: '1px 2% 3px 4.1grad'}], {padding: '1px 4.1grad 3px 2%'}],
@@ -67,6 +68,10 @@ const shortTests = [
   ],
   [[{padding: 10, direction: 'rtl'}], {padding: 10, direction: 'ltr'}],
   [[{margin: '1px 2px 3px 4px'}], {margin: '1px 4px 3px 2px'}],
+  [
+    [{margin: '1px var(--token) 3px 4px'}],
+    {margin: '1px 4px 3px var(--token)'},
+  ],
   [[{float: 'left'}], {float: 'right'}],
   [[{float: 'left !important'}], {float: 'right !important'}],
   [[{clear: 'left'}], {clear: 'right'}],
@@ -85,6 +90,10 @@ const shortTests = [
     {boxShadow: '6px 3px 8px 5px rgba(0, 0, 0, 0.25)'},
   ],
   [
+    [{boxShadow: '-6px 3px 8px 5px var(--css-variable)'}],
+    {boxShadow: '6px 3px 8px 5px var(--css-variable)'},
+  ],
+  [
     [{boxShadow: 'inset -6px 3px 8px 5px rgba(0, 0, 0, 0.25)'}],
     {boxShadow: 'inset 6px 3px 8px 5px rgba(0, 0, 0, 0.25)'},
   ],
@@ -98,6 +107,18 @@ const shortTests = [
   [
     [{boxShadow: '-1px 2px 3px 3px red, -1px 2px 3px 3px red'}],
     {boxShadow: '1px 2px 3px 3px red, 1px 2px 3px 3px red'},
+  ],
+  [
+    [
+      {
+        boxShadow:
+          '-1px 2px 3px 3px var(--css-variable), -1px 2px 3px 3px var(--anotherVariable)',
+      },
+    ],
+    {
+      boxShadow:
+        '1px 2px 3px 3px var(--css-variable), 1px 2px 3px 3px var(--anotherVariable)',
+    },
   ],
   [
     [
@@ -464,6 +485,7 @@ const unchanged = [
   [{objectPosition: 'center bottom'}],
   [{objectPosition: '5px 10px'}], // There's no RTL-flipped equivalent for the 5px. :-(
   [{boxShadow: 'var(--shadow16)'}],
+  [{boxShadow: 'var(--shadow-16)'}],
   [{margin: 'var(--margin)'}],
   [{transform: 'translate(var(--distance))'}],
   [{transform: 'var(--transform)'}],

--- a/src/internal/convert.js
+++ b/src/internal/convert.js
@@ -117,7 +117,7 @@ export function getValueDoppelganger(key, originalValue) {
   }
 
   if (isObject(originalValue)) {
-    return convert(originalValue) // recurssion 🌀
+    return convert(originalValue) // recursion 🌀
   }
   const isNum = isNumber(originalValue)
   const isFunc = isFunction(originalValue)

--- a/src/internal/property-value-converters.js
+++ b/src/internal/property-value-converters.js
@@ -19,13 +19,16 @@ const propertyValueConverters = {
   textShadow({value}) {
     const flippedShadows = splitShadow(value).map(shadow => {
       // intentionally leaving off the `g` flag here because we only want to change the first number (which is the offset-x)
-      return shadow.replace(/(-*)([.|\d]+)/, (match, negative, number) => {
-        if (number === '0') {
-          return match
-        }
-        const doubleNegative = negative === '' ? '-' : ''
-        return `${doubleNegative}${number}`
-      })
+      return shadow.replace(
+        /(^|\s)(-*)([.|\d]+)/,
+        (match, whiteSpace, negative, number) => {
+          if (number === '0') {
+            return match
+          }
+          const doubleNegative = negative === '' ? '-' : ''
+          return `${whiteSpace}${doubleNegative}${number}`
+        },
+      )
     })
 
     return flippedShadows.join(',')

--- a/src/internal/utils.js
+++ b/src/internal/utils.js
@@ -11,10 +11,6 @@ function arrayToObject(array) {
   }, {})
 }
 
-function containsCssVar(val) {
-  return typeof val === 'string' && val.match(/var\(.*\)/g)
-}
-
 function isBoolean(val) {
   return typeof val === 'boolean'
 }
@@ -141,9 +137,7 @@ function handleQuartetValues(value) {
  * @returns If the css property value can(should?) have an RTL equivalent
  */
 function canConvertValue(value) {
-  return (
-    !isBoolean(value) && !isNullOrUndefined(value) && !containsCssVar(value)
-  )
+  return !isBoolean(value) && !isNullOrUndefined(value)
 }
 
 /**
@@ -192,7 +186,6 @@ export {
   handleQuartetValues,
   includes,
   isBoolean,
-  containsCssVar,
   isFunction,
   isNumber,
   isNullOrUndefined,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Re-adds support for flipping CSS properties which contain CSS `var()` which has been removed by #62.
Fixes #61 by improving the regex.

**Why**:

As stated in #62, there are cases where, when the CSS variable is used, there is no way how how the value can be flipped:

```js
padding: 'var(--foo)'; /* 🔴 No way how to flip - foo can be a single value as well as four? */
```

On the other hand, there are other use cases, where the flipping is possible and meaningful:
```js
padding: margin: '1px var(--token) 3px 4px'; /* ✅ should be flipped to '1px 4px 3px var(--token)' */
boxShadow: '6px 3px 8px 5px var(--css-variable); /* ✅ CSS variable used only for color, offset can be safely flipped */
```

**How**:

Reverted the CSS variable check introduced in #62.

To fix the #61 which was the #62 addressing, I updated the regex used to flip `shadow` property to only match a number after a whitespace (or at the beginning of the string).

**Caveats**
If CSS variable is used for the first value in `shadow`, the flipped result might be wrong:
```js
boxShadow: 'var(--token) 3px 4px red' /* 💥 3px is considered the first number and is flipped to -3px */
```
This is the expected result if the `--token` resolves to `inset` but incorrect if it resolves to a number. In that case the `3px` is `offset-y` which should not have been flipped.

Takeaway: flipping values which contain CSS variables is problematic, styles authors must know what they are doing. As there are still valid and safe use cases, this behavior is better than just strictly disallowing anything what contains a CSS variable to be flipped.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
