### PR TITLE
chore: add export maps to support native ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,30 @@
   "jsnext:main": "dist/esm/index.js",
   "module": "dist/esm/index.js",
   "types": "types.d.ts",
+  "exports": {
+    ".": {
+      "types": "./types.d.ts",
+      "node": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./core": {
+      "types": "./core.d.ts",
+      "node": "./dist/cjs/core.js",
+      "import": "./dist/esm/core.js",
+      "default": "./dist/cjs/core.js"
+    },
+    "./core.esm": {
+      "default": "./dist/esm/core.js"
+    },
+    "./core.esm.js": {
+      "default": "./dist/esm/core.js"
+    },
+    "./core.js": {
+      "default": "./dist/cjs/core.js"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "build": "rimraf dist && npm-run-all build:**",
     "build:bundlers": "kcd-scripts build --bundle cjs,esm --environment BUILD_INPUT:src/*.js --no-clean",


### PR DESCRIPTION
**What**:

Fixes #68.

**Why**:

We would like to use `/core` as an entrypoint in our code, currently it impossible as `rtl-css-js/core` is a directory and we will get `ERR_UNSUPPORTED_DIR_IMPORT` from Node/bundlers 😨 

**How**:

This PR adds import maps, I initially wanted to use `import` & `require` pair (see [docs](https://nodejs.org/api/packages.html#conditional-exports)), but then I will have to change bundling process **drastically** and use something that emits `.cjs`/`.js` or `.js`/`.mjs` like [tsup](https://tsup.egoist.dev/).

_Why?!_
- `type: "module"` tells Node to have all `.js` as ESM, to use CJS - use `.cjs` files
- `type: "commonjs"` tells Node to have all `.js` as CJS, to use ESM - use `.mjs` files
- 💥 

```
(node:23063) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
/node_modules/rtl-css-js/dist/esm/core.js:1
export { f as arrayToObject, h as calculateNewBackgroundPosition, j as calculateNewTranslate, i as canConvertValue, c as convert, d as convertProperty, k as flipSign, j as flipTransformSign, g as getPropertyDoppelganger, e as getValueDoppelganger, u as getValuesAsList, l as handleQuartetValues, m as includes, n as isBoolean, o as isFunction, r as isNullOrUndefined, q as isNumber, s as isObject, t as isString, a as propertiesToConvert, p as propertyValueConverters, b as propsToIgnore, w as splitShadow, v as valuesToConvert } from './convert-7f74cdb7.js';
```

So, I went with another option that I have seen in Babel's packages ([reference](https://cdn.jsdelivr.net/npm/@babel/runtime@7.20.6/package.json)):
- don't set `type` (yeah, reference sets it, but this confuses Webpack)
- use `node` (specific to Node env), `import` (for bundlers) & `default`
- works in Node, works in Webpack ✅ 

**Tests**

#### Node / CJS

```js
// index.js
console.log("typeof require('rtl-css-js')", typeof require('rtl-css-js'))
console.log("typeof require('rtl-css-js/core')", typeof require('rtl-css-js/core'))
console.log("typeof require('rtl-css-js/core.js')", typeof require('rtl-css-js/core.js'))
console.log("typeof require('rtl-css-js/package.json')", typeof require('rtl-css-js/package.json'))
```

⬇️⬇️⬇️

```
$ node index.js
typeof require('rtl-css-js') function
typeof require('rtl-css-js/core') object
typeof require('rtl-css-js/core.js') object
typeof require('rtl-css-js/package.json') object
```

#### Node, ESM

```js
// index.mjs
console.log("typeof import('rtl-css-js')", typeof (await import('rtl-css-js')))
console.log("typeof import('rtl-css-js/core')", typeof (await import('rtl-css-js/core')))
```

⬇️⬇️⬇️

```
typeof import('rtl-css-js') object
typeof import('rtl-css-js/core') object
```

#### Webpack

```
// src/index.js
async function test() {
    console.log("typeof import('rtl-css-js')", typeof (await import('rtl-css-js')))
    console.log("typeof import('rtl-css-js/core')", typeof (await import('rtl-css-js/core')))
    console.log("typeof import('rtl-css-js/core.esm')", typeof (await import('rtl-css-js/core.esm')))
    console.log("typeof import('rtl-css-js/package.json')", typeof (await import('rtl-css-js/package.json')))
}

test().then(() => {})
```

⬇️⬇️⬇️

```
asset 346.js 7.22 KiB [compared for emit] [minimized] (id hint: vendors)
asset main.js 3.4 KiB [emitted] [minimized] (name: main)
asset 949.js 2.09 KiB [compared for emit] [minimized]
asset 503.js 707 bytes [compared for emit] [minimized]
asset 849.js 157 bytes [compared for emit] [minimized]
runtime modules 7.81 KiB 10 modules
cacheable modules 23.8 KiB
  modules by path ./node_modules/rtl-css-js/dist/esm/*.js 21.4 KiB
    ./node_modules/rtl-css-js/dist/esm/index.js 81 bytes [built] [code generated]
    ./node_modules/rtl-css-js/dist/esm/core.js 560 bytes [built] [code generated]
    ./node_modules/rtl-css-js/dist/esm/convert-7f74cdb7.js 20.8 KiB [built] [code generated]
  ./src/index.js 439 bytes [built] [code generated]
  ./node_modules/rtl-css-js/package.json 1.97 KiB [built] [code generated]

WARNING in configuration
The 'mode' option has not been set, webpack will fallback to 'production' for this value.
Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
You can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/

webpack 5.75.0 compiled with 1 warning in 245 ms
```

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation: N/A
- [x] Tests: Manually tested, with Webpack 5 & Node 16
- [x] Ready to be merged
- [x] Added myself to contributors table
